### PR TITLE
Removed aem-service dependency because aem-service is now triggered by conga-aem-cms

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,7 @@ The subdirectory inside the bundle directory.
 
 This role depends on the
 [conga-facts](https://github.com/wcm-io-devops/ansible-conga-facts) role
-for supplying the list of bundle files to deploy. It also depends on the
-[ansible-aem-service](https://github.com/wcm-io-devops/ansible-aem-service)
-role for ensuring that the target AEM instance is started before calling
-the API.
+for supplying the list of bundle files to deploy.
 
 ## Example
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,6 +24,3 @@ galaxy_info:
 allow_duplicates: yes
 dependencies:
   - conga-facts
-  - { name: aem-service,
-      aem_service_port: "{{ conga_aem_packages_port }}",
-      aem_service_name: "{{ aem_cms_service_name }}" }


### PR DESCRIPTION
Aonga-aem-packages also lists aem-service as dependency and there seems to be a bug in ansible which causes a doubled restart after installating the first aem package because the "aem restart" handler is triggered multiple times.