### PR TITLE
Add timeout option, use localhost as hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,22 @@ The username to use for the Bundle API call.
 
 The password to use for the Bundle API call.
 
-    conga_bundle_files_aem_port: "{{ conga_config.quickstart.port }}"
+    conga_bundle_files_aem_port: 4502
 
-The port of the target AEM instance (required). This can be set
+The port of the target AEM instance. This can be set
 explicitly, but the idea is to reuse it from a CONGA role in which the
 port is defined (e.g.
 [`aem-cms`](https://github.com/wcm-io-devops/conga-aem-definitions/blob/develop/conga-aem-definitions/src/main/roles/aem-cms.yaml))
 to make it automatically work for both author and publisher instances.
 
-    conga_bundle_files_aem_api_prefix: "http://{{ inventory_hostname }}:{{ conga_bundle_files_aem_port }}/system/console/bundles/"
+    conga_bundle_files_aem_api_prefix: "http://localhost:{{ conga_bundle_files_aem_port }}/system/console/bundles/"
 
 The prefix of the bundle API call made to retrieve the bundle id and
 thus the target path where to deploy the file.
+
+    conga_bundle_files_aem_api_timeout: 60
+
+Timeout in seconds for the AEM api call
 
     conga_bundle_files_target_dir_prefix: "crx-quickstart/launchpad/felix/bundle"
     

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,11 +2,17 @@
 conga_bundle_files_aem_user: admin
 conga_bundle_files_aem_password: admin
 
-# Port and package manager service URL of the AEM instance
-conga_bundle_files_aem_port: "{{ conga_config.quickstart.port }}"
-conga_bundle_files_aem_api_prefix: "http://{{ inventory_hostname }}:{{ conga_bundle_files_aem_port }}/system/console/bundles/"
+# The port of the target AEM instance
+conga_bundle_files_aem_port: 4502
+# The prefix of the bundle API call made to retrieve the bundle id and thus the target path where to deploy the file.
+conga_bundle_files_aem_api_prefix: "http://localhost:{{ conga_bundle_files_aem_port }}/system/console/bundles/"
 
+# Timeout in seconds for the AEM api call
+conga_bundle_files_aem_api_timeout: 60
+
+#The prefix of the bundle target path. This value is concatenated with the bundle id retrieved from the bundle API call.
 conga_bundle_files_target_dir_prefix: "crx-quickstart/launchpad/felix/bundle"
+# The subdirectory inside the bundle directory.
 conga_bundle_files_target_data_dir: "data"
 
 # Owner, group and mode of the copied files

--- a/tasks/deploy_bundle_file.yml
+++ b/tasks/deploy_bundle_file.yml
@@ -10,6 +10,7 @@
     force_basic_auth: yes
     user: "{{ conga_bundle_files_aem_user }}"
     password: "{{ conga_bundle_files_aem_password }}"
+    timeout: "{{ conga_bundle_files_aem_api_timeout }}"
     return_content: yes
   register: bundle_json
 


### PR DESCRIPTION
The calls to the API now use localhost as default.
Since the call is directly executed after initial AEM setup a configurable timeout was introduced.