### PR TITLE
Ansible 2.8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Enables/disables standalone mode. When set to true the
 dependency is enabled. Set this value to false when you have several
 aem-service dependencies in your play to avoid multiple AEM restarts.
 
-# Result facts
+## Result facts
 
     conga_bundle_files_changed
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ The username to use for the Bundle API call.
 
 The password to use for the Bundle API call.
 
-    conga_bundle_files_aem_port: "{{ conga_config.quickstart.port | default(4502) }}"
+    conga_bundle_files_aem_service_name: "{{ aem_cms_service_name }}"
+
+The name of the aem service, required in order to restart the instance.
+This must be set explicitely when not running along with the
+`wcm_io_devops.aem_cms` role.
+
+    conga_bundle_files_aem_service_port: "{{ conga_config.quickstart.port | default(4502) }}"
 
 The port of the target AEM instance. This can be set
 explicitly, but the idea is to reuse it from a CONGA role in which the
@@ -34,7 +40,7 @@ port is defined (e.g.
 [`aem-cms`](https://github.com/wcm-io-devops/conga-aem-definitions/blob/develop/conga-aem-definitions/src/main/roles/aem-cms.yaml))
 to make it automatically work for both author and publisher instances.
 
-    conga_bundle_files_aem_api_prefix: "http://localhost:{{ conga_bundle_files_aem_port }}/system/console/bundles/"
+    conga_bundle_files_aem_api_prefix: "http://localhost:{{ conga_bundle_files_aem_service_port }}/system/console/bundles/"
 
 The prefix of the bundle API call made to retrieve the bundle id and
 thus the target path where to deploy the file.

--- a/README.md
+++ b/README.md
@@ -58,12 +58,23 @@ the bundle id retrieved from the bundle API call.
 
 The subdirectory inside the bundle directory.
 
+    conga_bundle_files_handlers: []
+
+The handlers to notify when a bundle file has changed.
+
     conga_bundle_files_standalone: true
 
 Enables/disables standalone mode. When set to true the
 [wcm_io_devops.aem_service](https://github.com/wcm-io-devops/ansible-aem-service)
 dependency is enabled. Set this value to false when you have several
 aem-service dependencies in your play to avoid multiple AEM restarts.
+
+# Result facts
+
+    conga_bundle_files_changed
+
+This fact has the value `true` when at least one deployment of a bundle
+file resulted in a change.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,9 @@ conga_bundle_files_aem_user: "{{ conga_config.quickstart.adminUser.username | de
 conga_bundle_files_aem_password: "{{ conga_config.quickstart.adminUser.password | default('admin')}}"
 
 # The port of the target AEM instance
-conga_bundle_files_aem_port: "{{ conga_config.quickstart.port | default(4502) }}"
+conga_bundle_files_aem_service_port: "{{ conga_config.quickstart.port | default(4502) }}"
 # The prefix of the bundle API call made to retrieve the bundle id and thus the target path where to deploy the file.
-conga_bundle_files_aem_api_prefix: "http://localhost:{{ conga_bundle_files_aem_port }}/system/console/bundles/"
+conga_bundle_files_aem_api_prefix: "http://localhost:{{ conga_bundle_files_aem_service_port }}/system/console/bundles/"
 
 # Timeout in seconds for the AEM api call
 conga_bundle_files_aem_api_timeout: 60

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 conga_bundle_files_aem_user: "{{ conga_config.quickstart.adminUser.username | default('admin')}}"
 conga_bundle_files_aem_password: "{{ conga_config.quickstart.adminUser.password | default('admin')}}"
 
+# The name of the aem service, required in order to restart the instance after a change
+conga_bundle_files_aem_service_name: "{{ aem_cms_service_name }}"
+
 # The port of the target AEM instance
 conga_bundle_files_aem_service_port: "{{ conga_config.quickstart.port | default(4502) }}"
 # The prefix of the bundle API call made to retrieve the bundle id and thus the target path where to deploy the file.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,9 @@ conga_bundle_files_target_dir_prefix: "crx-quickstart/launchpad/felix/bundle"
 # The subdirectory inside the bundle directory.
 conga_bundle_files_target_data_dir: "data"
 
+# The handlers to register when a bundle file has changed
+conga_bundle_files_handlers: []
+
 # Owner, group and mode of the copied files
 #conga_bundle_files_owner:
 #conga_bundle_files_group:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,13 +25,11 @@ galaxy_info:
 
 allow_duplicates: yes
 dependencies:
-  - { name: wcm_io_devops.conga_facts,
-      version: 1.0.1
-  }
-  - { name: wcm_io_devops.aem_service,
-      version: 1.2.0,
-      aem_service_port: "{{ conga_bundle_files_aem_service_port }}",
-      aem_service_name: "{{ conga_bundle_files_aem_service_name }}",
-      aem_service_state: started
-      when: conga_bundle_files_standalone
-  }
+  - name: wcm_io_devops.conga_facts
+    version: 1.0.1
+  - name: wcm_io_devops.aem_service
+    version: 1.2.0
+    aem_service_port: "{{ conga_bundle_files_aem_service_port }}"
+    aem_service_name: "{{ conga_bundle_files_aem_service_name }}"
+    aem_service_state: started
+    when: conga_bundle_files_standalone

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,7 +30,8 @@ dependencies:
   }
   - { name: wcm_io_devops.aem_service,
       version: 1.2.0,
-      aem_service_port: "{{ conga_bundle_files_aem_port }}",
-      aem_service_name: "{{ aem_cms_service_name }}",
+      aem_service_port: "{{ conga_bundle_files_aem_service_port }}",
+      aem_service_name: "{{ conga_bundle_files_aem_service_name }}",
+      aem_service_state: started
       when: conga_bundle_files_standalone
   }

--- a/tasks/deploy_bundle_file.yml
+++ b/tasks/deploy_bundle_file.yml
@@ -32,7 +32,7 @@
   register: _conga_bundle_files_result
   notify: "{{ conga_bundle_files_handlers | default(omit) }}"
 
-- name: Restart AEM when bundle file(s) changed.
+- name: Restart AEM when bundle file(s) changed. # noqa 503
   import_role:
     name: wcm_io_devops.aem_service
   vars:

--- a/tasks/deploy_bundle_file.yml
+++ b/tasks/deploy_bundle_file.yml
@@ -29,14 +29,11 @@
     owner: "{{ conga_bundle_files_owner | default(omit) }}"
     group: "{{ conga_bundle_files_group | default(omit) }}"
     mode: "{{ conga_bundle_files_mode | default(omit) }}"
-  register: _conga_bundle_files_result
+  register: _conga_bundle_files_bundle_file_result
   notify: "{{ conga_bundle_files_handlers | default(omit) }}"
 
-- name: Restart AEM when bundle file(s) changed. # noqa 503
-  import_role:
-    name: wcm_io_devops.aem_service
-  vars:
-    aem_service_name: "{{ conga_bundle_files_aem_service_name | mandatory }}"
-    aem_service_port: "{{ conga_bundle_files_aem_service_port | mandatory }}"
-    aem_service_state: restarted
-  when: _conga_bundle_files_result.changed
+- name: "Set 'conga_bundle_files_changed' to true when changed."
+  set_fact:
+    conga_bundle_files_changed: true
+  changed_when: true
+  when: _conga_bundle_files_bundle_file_result.changed

--- a/tasks/deploy_bundle_file.yml
+++ b/tasks/deploy_bundle_file.yml
@@ -29,4 +29,14 @@
     owner: "{{ conga_bundle_files_owner | default(omit) }}"
     group: "{{ conga_bundle_files_group | default(omit) }}"
     mode: "{{ conga_bundle_files_mode | default(omit) }}"
+  register: _conga_bundle_files_result
   notify: "{{ conga_bundle_files_handlers | default(omit) }}"
+
+- name: Restart AEM when bundle file(s) changed.
+  import_role:
+    name: wcm_io_devops.aem_service
+  vars:
+    aem_service_name: "{{ conga_bundle_files_aem_service_name | mandatory }}"
+    aem_service_port: "{{ conga_bundle_files_aem_service_port | mandatory }}"
+    aem_service_state: restarted
+  when: _conga_bundle_files_result.changed

--- a/tasks/deploy_bundle_file.yml
+++ b/tasks/deploy_bundle_file.yml
@@ -32,7 +32,7 @@
   register: _conga_bundle_files_bundle_file_result
   notify: "{{ conga_bundle_files_handlers | default(omit) }}"
 
-- name: "Set 'conga_bundle_files_changed' to true when changed."
+- name: "Set 'conga_bundle_files_changed' to true when changed." # noqa 503
   set_fact:
     conga_bundle_files_changed: true
   changed_when: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
-- name: Setup bundle_file list.
+- name: Setup bundle_file list and result fact.
   set_fact:
     _bundle_files: "{{ bundle_files | default(conga_bundle_files) }}"
+    conga_bundle_files_changed: false
 
 - name: "Deploy AEM bundle files for role: {{ conga_role }}"
   include_tasks: deploy_bundle_file.yml


### PR DESCRIPTION
This PR will require a major release because we are renaming one variable:
* `conga_bundle_files_aem_port` was renamed to `conga_bundle_files_aem_service_port`
* we are introducing `conga_bundle_files_aem_service_name` in order to make the AEM instance name configurable
* explicitely set aem_service_state for role "wcm_io_devops.aem_service"

We will add a result fact `conga_bundle_files_changed` which can have the values `true` or `false`.
This result will then used by the [wcm_io_devops.conga_aem_cms](https://github.com/wcm-io-devops/ansible-conga-aem-cms) role to evaluate if a restart will be required or not. 